### PR TITLE
Forbid archery until the match has started

### DIFF
--- a/1vs1/src/vixikhd/onevsone/arena/Arena.php
+++ b/1vs1/src/vixikhd/onevsone/arena/Arena.php
@@ -516,9 +516,6 @@ class Arena implements Listener
 		}
 	}
 
-        /**
-        * @param EntityShootBowEvent $event
-        */
         public function onShot(EntityShootBowEvent $event) :void
         {
               $player = $event->getEntity();

--- a/1vs1/src/vixikhd/onevsone/arena/Arena.php
+++ b/1vs1/src/vixikhd/onevsone/arena/Arena.php
@@ -516,6 +516,18 @@ class Arena implements Listener
 		}
 	}
 
+        /**
+        * @param EntityShootBowEvent $event
+        */
+        public function onShot(EntityShootBowEvent $event) :void
+        {
+              $player = $event->getEntity();
+              if($player instanceof Player) {
+                  if($this->inGame($player) && $this->phase !== 1)
+                      $event->cancel();
+              }
+        }
+
 	public function __destruct()
 	{
 		unset($this->scheduler);


### PR DESCRIPTION
There is such a bug that when the timer is running before the duel starts and the players have a bow, they can kill each other before the duel starts. This pull will fix this bug.